### PR TITLE
Add a simple way to test QE XSD schema

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -56,6 +56,13 @@ run-tests-pw-serial : prolog pseudo
 run-tests-pw-parallel : prolog pseudo
 	env QE_USE_MPI=1 ${TESTCODE_DIR}/bin/testcode.py --verbose --category=pw_all
 
+run-tests-xsd-pw-serial : prolog pseudo
+	cd xsd_pw ; for file in ./*.in ; do \
+		echo "Running using $$file" ; \
+		env QE_USE_MPI=0 ../run-pw.sh -in $$file &> $$file.out ; \
+		python ../validate_xsd_pw.py $$file; \
+	done ; cd ..
+
 run-tests-epw-serial : prolog pseudo
 	env QE_USE_MPI=0 ${TESTCODE_DIR}/bin/testcode.py --verbose --category=epw_all
 

--- a/test-suite/validate_xsd_pw.py
+++ b/test-suite/validate_xsd_pw.py
@@ -25,7 +25,10 @@ KS_ENERGIES_TAG = BAND_STRUCTURE_TAG + '/ks_energies'
 
 TOLS = dict()
 TOLS[TOT_ENERGY_TAG] = 5
+TOLS[EFERMI_TAG] = 5
 TOLS[NBND_TAG] = 0
+TOLS[NKS_TAG] = 0
+TOLS[DFT_FUNCT_TAG] = -1 # str
 TOLS[ECUTWFC_TAG] = 2
 TOLS[ECUTRHO_TAG] = 2
 
@@ -35,7 +38,10 @@ XMLValidation = namedtuple('XMLValidation', ('tag', 'attrib', 'ref_value'))
 VALIDATION_DICT = dict()
 VALIDATION_DICT['WaterP1_0_scf_0'] = list()
 VALIDATION_DICT['WaterP1_0_scf_0'].append(XMLValidation(TOT_ENERGY_TAG, False, -16.91816749))
+VALIDATION_DICT['WaterP1_0_scf_0'].append(XMLValidation(EFERMI_TAG, False, 0.18547017))
 VALIDATION_DICT['WaterP1_0_scf_0'].append(XMLValidation(NBND_TAG, False, 14))
+VALIDATION_DICT['WaterP1_0_scf_0'].append(XMLValidation(NKS_TAG, False, 8))
+VALIDATION_DICT['WaterP1_0_scf_0'].append(XMLValidation(DFT_FUNCT_TAG, False, 'PBE'))
 VALIDATION_DICT['WaterP1_0_scf_0'].append(XMLValidation(ECUTWFC_TAG, False, 20))
 VALIDATION_DICT['WaterP1_0_scf_0'].append(XMLValidation(ECUTRHO_TAG, False, 100))
 

--- a/test-suite/validate_xsd_pw.py
+++ b/test-suite/validate_xsd_pw.py
@@ -1,0 +1,82 @@
+from collections import namedtuple
+import os
+import sys
+import unittest
+from xml.etree import ElementTree
+
+
+OUTPUT_TAG = 'output'
+ATOMIC_STRUCTURE_TAG = OUTPUT_TAG + '/atomic_structure'
+ATOMIC_POSITIONS_TAG = ATOMIC_STRUCTURE_TAG + '/atomic_positions'
+CELL_VECTORS_TAG = ATOMIC_STRUCTURE_TAG + '/cell/a%d'
+
+TOT_ENERGY_TAG = OUTPUT_TAG + '/total_energy/etot'
+ECUTWFC_TAG = OUTPUT_TAG + '/basis_set/ecutwfc'
+ECUTRHO_TAG = OUTPUT_TAG + '/basis_set/ecutrho'
+DFT_FUNCT_TAG = OUTPUT_TAG + '/dft/functional'
+BAND_STRUCTURE_TAG = OUTPUT_TAG + '/band_structure'
+NBND_TAG = BAND_STRUCTURE_TAG + '/nbnd'
+NKS_TAG = BAND_STRUCTURE_TAG + '/nks'
+NBND_UP_TAG = BAND_STRUCTURE_TAG + '/nbnd_up'
+NBND_DW_TAG = BAND_STRUCTURE_TAG + '/nbnd_dw'
+EFERMI_TAG = BAND_STRUCTURE_TAG + '/fermi_energy'
+HOMO_TAG = BAND_STRUCTURE_TAG + '/highestOccupiedLevel'
+KS_ENERGIES_TAG = BAND_STRUCTURE_TAG + '/ks_energies'
+
+TOLS = dict()
+TOLS[TOT_ENERGY_TAG] = 5
+TOLS[NBND_TAG] = 0
+TOLS[ECUTWFC_TAG] = 2
+TOLS[ECUTRHO_TAG] = 2
+
+XMLValidation = namedtuple('XMLValidation', ('tag', 'attrib', 'ref_value'))
+
+# Do not use defaultdict here, since it won't throw KeyError exceptions
+VALIDATION_DICT = dict()
+VALIDATION_DICT['WaterP1_0_scf_0'] = list()
+VALIDATION_DICT['WaterP1_0_scf_0'].append(XMLValidation(TOT_ENERGY_TAG, False, -16.91816749))
+VALIDATION_DICT['WaterP1_0_scf_0'].append(XMLValidation(NBND_TAG, False, 14))
+VALIDATION_DICT['WaterP1_0_scf_0'].append(XMLValidation(ECUTWFC_TAG, False, 20))
+VALIDATION_DICT['WaterP1_0_scf_0'].append(XMLValidation(ECUTRHO_TAG, False, 100))
+
+
+class XMLTester(unittest.TestCase):
+    def _assertXML(self, xml_fn, xml_validation):
+        tree = ElementTree.parse(xml_fn)
+        root = tree.getroot()
+
+        ref = xml_validation.ref_value
+        tol = TOLS[xml_validation.tag]
+
+        if tol > 0:
+            type_ = float
+            assert_funct = lambda val: self.assertAlmostEqual(val, ref, tol)
+        elif TOLS[xml_validation.tag] == 0:
+            type_ = int
+            assert_funct = lambda val: self.assertEqual(val, ref)
+        else:
+            type_ = str
+            assert_funct = lambda val: self.assertEqual(val, ref)
+
+        if xml_validation.attrib:
+            val = type_(root.find(xml_validation.tag).attrib[xml_validation.attrib].strip())
+        else:
+            val = type_(root.find(xml_validation.tag).text.strip())
+
+        assert_funct(val)
+
+    def testFiles(self):
+        inp_fn, ext = os.path.basename(sys.argv[1]).split('.')
+        xml_fn = os.path.join(inp_fn + '.save', 'data-file-schema.xml')
+        for xml_validator in VALIDATION_DICT[inp_fn]:
+            self._assertXML(xml_fn, xml_validator)
+
+
+if __name__ == '__main__':
+    if sys.version_info < (2, 7, 0):
+        sys.stderr.write("You need python 2.7 or later to run this program\n")
+        sys.exit(1)
+    # This is needed to run tests from the command line:
+    # https://tellthemuserstories.wordpress.com/2013/01/19/python-unittest-command-line-argument/amp/
+    suite = unittest.TestLoader().loadTestsFromTestCase(XMLTester)
+    unittest.TextTestRunner().run(suite)

--- a/test-suite/xsd_pw/WaterP1_0_scf_0.in
+++ b/test-suite/xsd_pw/WaterP1_0_scf_0.in
@@ -1,0 +1,80 @@
+&CONTROL
+ calculation='scf'
+ dipfield=.false.
+ disk_io='low'
+ dt=20.0
+ etot_conv_thr=1e-05
+ forc_conv_thr=0.001
+ input_xml_schema_file='WaterP1_0_scf_0.xml'
+ iprint=1
+ max_seconds=1000000
+ nstep=50
+ outdir='./'
+ prefix='WaterP1_0_scf_0'
+ restart_mode='from_scratch'
+ title='Default Title'
+ tprnfor=.false.
+ tstress=.false.
+ verbosity='high'
+ wf_collect=.false.
+/
+&SYSTEM
+ degauss=0.01
+ ecutrho=200.0
+ ecutwfc=40.0
+ force_symmorphic=.false.
+ ibrav=0
+ input_dft='PBE'
+ lspinorb=.false.
+ nat=3
+ nbnd=14
+ no_t_rev=.false.
+ noinv=.false.
+ noncolin=.false.
+ nosym=.true.
+ nosym_evc=.false.
+ nspin=1
+ ntyp=2
+ occupations='smearing'
+ smearing='gaussian'
+ starting_magnetization(1)=0.0
+ starting_magnetization(2)=0.0
+ tot_charge=0.0
+ use_all_frac=.false.
+/
+&ELECTRONS
+ conv_thr=1e-06
+ diago_cg_maxiter=20
+ diago_full_acc=.false.
+ diago_thr_init=0.0
+ diagonalization='davidson'
+ electron_maxstep=100
+ mixing_beta=0.7
+ mixing_mode='plain'
+ mixing_ndim=8
+ tbeta_smoothing=.false.
+ tq_smoothing=.false.
+ tqr=.false.
+/
+&IONS
+ ion_dynamics='bfgs'
+/
+&CELL
+ cell_dynamics='bfgs'
+ press=0.0
+ press_conv_thr=0.5
+/
+ATOMIC_SPECIES
+ H 1.00794 H.blyp-vbc.UPF
+ O 15.9994 O.blyp-mt.UPF
+ATOMIC_POSITIONS bohr
+ O 0.0 0.0 0.0
+ H 1.593778 1.01535 0.0
+ H 5.373232 1.01535 0.0
+K_POINTS automatic
+ 2 2 4 1 1 1
+CELL_PARAMETERS bohr
+ 6.96701 0.0 0.0
+ 0.0 4.794801 0.0
+ 0.0 0.0 3.779452
+ 


### PR DESCRIPTION
This will fail with:

```
make run-tests-xsd-pw
cd xsd_pw ; for file in ./*.in ; do \
        echo "Running using $file" ; \
        env QE_USE_MPI=0 ../run-pw.sh -in $file &> $file.out ; \
        python ../validate_xsd_pw.py $file; \
    done ; cd ..
Running using ./WaterP1_0_scf_0.in
F
======================================================================
FAIL: testFiles (__main__.XMLTester)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "../validate_xsd_pw.py", line 72, in testFiles
    self._assertXML(xml_fn, xml_validator)
  File "../validate_xsd_pw.py", line 66, in _assertXML
    assert_funct(val)
  File "../validate_xsd_pw.py", line 53, in <lambda>
    assert_funct = lambda val: self.assertAlmostEqual(val, ref, tol)
AssertionError: -8.459084 != -16.91816749 within 5 places
```

Ground state energy is currently wrong in XSD output.
