### PR TITLE
correct pseudo_dir path in EPW examples

### DIFF
--- a/EPW/examples/pb/wSOC/phonons/scf.in
+++ b/EPW/examples/pb/wSOC/phonons/scf.in
@@ -1,7 +1,7 @@
  &control
     calculation='scf',
     prefix='pb',
-    pseudo_dir = '../pp/',
+    pseudo_dir = '../../pp/',
     outdir='./',
     tprnfor = .true.,
     tstress = .true.,


### PR DESCRIPTION
The example failed due to not finding the pseudo potential. Upon comparison with the woSOC scf.in, the wrong path to the pseudo potential was obvious. Should be easily mergeable :)